### PR TITLE
Produce valid JSON for all input with the logstash log format.

### DIFF
--- a/curator/curator.py
+++ b/curator/curator.py
@@ -1,7 +1,6 @@
 import time
 import logging
 import re
-import json
 from datetime import timedelta, datetime, date
 
 import elasticsearch
@@ -204,7 +203,7 @@ def get_snaplist(client, repository='', snapshot_prefix='curator-'):
         pattern = re.compile(regex)
         return list(filter(lambda x: pattern.search(x), snaps))
     except elasticsearch.NotFoundError as e:
-        logger.error(json.dumps("Error: {0}".format(e)))
+        logger.error("Error: {0}".format(e))
     return retval
 
 ### Repository information
@@ -219,7 +218,7 @@ def get_repository(client, repository=''):
     try:
         return client.snapshot.get_repository(repository=repository)
     except elasticsearch.NotFoundError as e:
-        logger.error(json.dumps("Repository {0} not found.  Error: {1}".format(repository, e)))
+        logger.error("Repository {0} not found.  Error: {1}".format(repository, e))
         return None
 
 ### Single snapshot information
@@ -235,7 +234,7 @@ def get_snapshot(client, repository='', snapshot=''):
     try:
         return client.snapshot.get(repository=repository, snapshot=snapshot)
     except elasticsearch.NotFoundError as e:
-        logger.error(json.dumps("Snapshot or repository {0} not found.  Error: {1}".format(snapshot, e)))
+        logger.error("Snapshot or repository {0} not found.  Error: {1}".format(snapshot, e))
         return None
 
 ## ES version
@@ -372,7 +371,7 @@ def filter_by_timestamp(object_list=[], timestring=None, time_unit='days',
             try:
                 index_timestamp = re.search(regex, object_name).group(1)
             except AttributeError as e:
-                logger.debug(json.dumps('Unable to match {0} with regular expression {1}.  Error: {2}'.format(object_name, regex, e)))
+                logger.debug('Unable to match {0} with regular expression {1}.  Error: {2}'.format(object_name, regex, e))
                 continue
             try:
                 object_time = get_index_time(index_timestamp, timestring)
@@ -383,12 +382,12 @@ def filter_by_timestamp(object_list=[], timestring=None, time_unit='days',
             try:
                 retval = re.search(regex, object_name['snapshot']).group(1)
             except AttributeError as e:
-                logger.debug(json.dumps('Unable to match {0} with regular expression {1}.  Error: {2}'.format(retval, regex, e)))
+                logger.debug('Unable to match {0} with regular expression {1}.  Error: {2}'.format(retval, regex, e))
                 continue
             try:
                 object_time = datetime.utcfromtimestamp(object_name['start_time_in_millis']/1000.0)
             except AttributeError as e:
-                logger.debug(json.dumps('Unable to compare time from snapshot {0}.  Error: {1}'.format(object_name, e)))
+                logger.debug('Unable to compare time from snapshot {0}.  Error: {1}'.format(object_name, e))
                 continue
             # if the index is older than the cutoff
         if object_time < cutoff:
@@ -690,7 +689,7 @@ def create_snapshot(client, indices='_all', snapshot_name=None,
             try:
                 client.snapshot.create(repository=repository, snapshot=snapshot_name, body=body, wait_for_completion=wait_for_completion)
             except elasticsearch.TransportError as e:
-                logger.error(json.dumps("Client raised a TransportError.  Error: {0}".format(e)))
+                logger.error("Client raised a TransportError.  Error: {0}".format(e))
                 return True
         elif len(indices) == 0:
             logger.warn("No indices provided.")
@@ -699,7 +698,7 @@ def create_snapshot(client, indices='_all', snapshot_name=None,
             logger.info("Skipping: A snapshot with name '{0}' already exists.".format(snapshot_name))
             return True
     except elasticsearch.RequestError as e:
-        logger.error(json.dumps("Unable to create snapshot {0}.  Error: {1} Check logs for more information.".format(snapshot_name, e)))
+        logger.error("Unable to create snapshot {0}.  Error: {1} Check logs for more information.".format(snapshot_name, e))
         return True
 
 ### Delete a snapshot
@@ -718,7 +717,7 @@ def delete_snapshot(client, snap, **kwargs):
     try:
         client.snapshot.delete(repository=repository, snapshot=snap)
     except elasticsearch.RequestError as e:
-        logger.error(json.dumps("Unable to delete snapshot {0}.  Error: {1} Check logs for more information.".format(snap, e)))
+        logger.error("Unable to delete snapshot {0}.  Error: {1} Check logs for more information.".format(snap, e))
 
 # Operations typically used by the curator_script, directly or indirectly
 ## Loop through a list of objects and perform the indicated operation

--- a/curator/curator_script.py
+++ b/curator/curator_script.py
@@ -5,6 +5,7 @@ import sys
 import time
 import logging
 from datetime import timedelta, datetime, date
+import json
 
 import elasticsearch
 import curator
@@ -187,6 +188,27 @@ def make_parser():
 
     return parser
 
+class LogstashFormatter(logging.Formatter):
+    # The LogRecord attributes we want to carry over to the Logstash message,
+    # mapped to the corresponding output key.
+    WANTED_ATTRS = {'levelname': 'loglevel',
+                    'funcName': 'function',
+                    'lineno': 'linenum',
+                    'message': 'message',
+                    'name': 'name'}
+
+    def converter(self, timevalue):
+        return time.gmtime(timevalue)
+
+    def format(self, record):
+        timestamp = '%s.%03dZ' % (
+            self.formatTime(record, datefmt='%Y-%m-%dT%H:%M:%S'), record.msecs)
+        result = {'message': record.getMessage(),
+                  '@timestamp': timestamp}
+        for attribute in set(self.WANTED_ATTRS).intersection(record.__dict__):
+            result[self.WANTED_ATTRS[attribute]] = getattr(record, attribute)
+        return json.dumps(result, sort_keys=True)
+
 class Whitelist(logging.Filter):
     def __init__(self, *whitelist):
         self.whitelist = [logging.Filter(name) for name in whitelist]
@@ -311,17 +333,14 @@ def main():
         if not isinstance(numeric_log_level, int):
             raise ValueError('Invalid log level: %s' % arguments.log_level)
     
-    date_string = None
+    handler = logging.StreamHandler(
+        open(arguments.log_file, 'a') if arguments.log_file else sys.stderr)
     if arguments.logformat == 'logstash':
-        os.environ['TZ'] = 'UTC'
-        time.tzset()
-        format_string = '{"@timestamp":"%(asctime)s.%(msecs)03dZ", "loglevel":"%(levelname)s", "name":"%(name)s", "function":"%(funcName)s", "linenum":"%(lineno)d", "message":"%(message)s"}'
-        date_string = '%Y-%m-%dT%H:%M:%S'
-
-    logging.basicConfig(level=numeric_log_level,
-                        format=format_string,
-                        datefmt=date_string,
-                        stream=open(arguments.log_file, 'a') if arguments.log_file else sys.stderr)
+        handler.setFormatter(LogstashFormatter())
+    else:
+        handler.setFormatter(logging.Formatter(format_string))
+    logging.root.addHandler(handler)
+    logging.root.setLevel(numeric_log_level)
 
     # Filter out logging from Elasticsearch and associated modules by default
     if not arguments.debug:


### PR DESCRIPTION
The old method of constructing the log messages for the logstash
format produced invalid JSON for certain input. We avoid this by
instead using Python's standard json library for producing the JSON
string. As a bonus this allows us to drop several json.dumps() calls
in the log statements themselves. This addresses issue #248.