### PR TITLE
Add --not-older-than argument

### DIFF
--- a/curator/curator.py
+++ b/curator/curator.py
@@ -328,8 +328,9 @@ def get_object_list(client, data_type='index', prefix='logstash-', suffix='', re
 # Filtering
 ## By timestamp
 def filter_by_timestamp(object_list=[], timestring=None, time_unit='days',
-                        older_than=999999, prefix='logstash-', suffix='',
-                        snapshot_prefix='curator-', utc_now=None, **kwargs):
+                        older_than=None, not_older_than=None,
+                        prefix='logstash-', suffix='', utc_now=None,
+                        snapshot_prefix='curator-', **kwargs):
     """
     Pass in a list of indices or snapshots. Return a list of objects older
     than *n* ``time_unit``\s matching ``prefix``, ``timestring``, and
@@ -363,8 +364,11 @@ def filter_by_timestamp(object_list=[], timestring=None, time_unit='days',
     elif object_type == 'snapshot':
         regex = "(" + "^" + snapshot_prefix + '.*' + ")"
 
-    cutoff = get_cutoff(older_than=older_than, time_unit=time_unit, utc_now=utc_now)
-    
+    if older_than:
+        cutoff_older = get_cutoff(older_than=older_than, time_unit=time_unit, utc_now=utc_now)
+    if not_older_than:
+        cutoff_not_older = get_cutoff(older_than=not_older_than, time_unit=time_unit, utc_now=utc_now)
+
     for object_name in object_list:
         retval = object_name
         if object_type == 'index':
@@ -389,11 +393,12 @@ def filter_by_timestamp(object_list=[], timestring=None, time_unit='days',
             except AttributeError as e:
                 logger.debug('Unable to compare time from snapshot {0}.  Error: {1}'.format(object_name, e))
                 continue
-            # if the index is older than the cutoff
-        if object_time < cutoff:
-            yield retval
+        if older_than and object_time >= cutoff_older:
+            logger.info('{0} is not older than --older-than ({1} {2}).'.format(retval, older_than, time_unit))
+        elif not_older_than and object_time <= cutoff_not_older:
+            logger.info('{0} is older than --not-older-than ({1} {2}).'.format(retval, not_older_than, time_unit))
         else:
-            logger.info('{0} is within the threshold period ({1} {2}).'.format(retval, older_than, time_unit))
+            yield retval
 
 ## By space
 def filter_by_space(client, disk_space=2097152.0, prefix='logstash-', suffix='',
@@ -849,6 +854,8 @@ def allocation(client, dry_run=False, **kwargs):
     :arg dry_run: If true, simulate, but do not perform the operation
     :arg older_than: Indices older than the indicated number of whole
         ``time_units`` will be operated on.
+    :arg not_older_than: Indices older than the indicated number of whole
+        ``time_units`` will NOT be operated on.
     :arg time_unit: One of ``hours``, ``days``, ``weeks``, ``months``.  Default
         is ``days``.
     :arg timestring: An strftime string to match the datestamp in an index name.

--- a/curator/curator_script.py
+++ b/curator/curator_script.py
@@ -112,6 +112,7 @@ def make_parser():
     parser_allocation.set_defaults(func=curator.allocation)
     add_common_args(parser_allocation)
     parser_allocation.add_argument('--older-than', required=True, help='Apply rule to indices older than n TIME_UNITs', type=int)
+    parser_allocation.add_argument('--not-older-than', required=False, help='Don\'t apply rule to indices older than n TIME_UNITs', type=int)
     parser_allocation.add_argument('--rule', required=True, help='Routing allocation rule to apply, e.g. tag=ssd', type=str)
 
     # Bloom

--- a/test_curator/unit/test_filter_by_timestamp.py
+++ b/test_curator/unit/test_filter_by_timestamp.py
@@ -1,0 +1,18 @@
+from datetime import datetime, timedelta
+from unittest import TestCase
+
+import curator
+
+
+class TestFilterByTimestamp(TestCase):
+    def test_filter_by_timestamp(self):
+        object_list = ['logstash-2014.01.01', 'logstash-2014.01.02',
+                       'logstash-2014.01.03', 'logstash-2014.01.04']
+        timestring = '%Y.%m.%d'
+        utc_now = datetime(2014, 1, 4, 0, 00, 00)
+        res = curator.filter_by_timestamp(object_list=object_list, suffix='',
+                                          timestring=timestring,
+                                          time_unit='days', older_than=1,
+                                          not_older_than=3, prefix='logstash-',
+                                          utc_now=utc_now)
+        assert list(res) == ['logstash-2014.01.03']


### PR DESCRIPTION
This PR adds a ``--not-older-than`` argument for the ``allocation`` sub-command, useful for when you want to work on a sub-set of indices.
Our use case is a more-than-2-tiered cluster and we want to move indices between our 3 tiers and ``--not-older-than`` will ease that work.

I've only added the option to the ``allocation`` sub-command because that is our use-case, implementing the same functionality for the other sub-commands should be rather easy.

I've added a unittest folder as well as I didn't see a reason to do a full integration test on this small piece of logic. 