### PR TITLE
Add functionality to open indices and set shards per node

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ See the [Curator Wiki](http://github.com/elasticsearch/curator/wiki) on Github f
 * bloom - Disable bloom filter cache for expired indices
 * close - Close indices
 * delete - Delete indices
+* open - Open indices
 * optimize - Optimize (Lucene forceMerge) indices
 * show - Show indices or snapshots
 * snapshot - Snapshot indices to existing repository

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ See the [Curator Wiki](http://github.com/elasticsearch/curator/wiki) on Github f
 * delete - Delete indices
 * open - Open indices
 * optimize - Optimize (Lucene forceMerge) indices
+* shardspernode - Set the number of shards per node
 * show - Show indices or snapshots
 * snapshot - Snapshot indices to existing repository
     

--- a/curator/curator.py
+++ b/curator/curator.py
@@ -516,7 +516,7 @@ def apply_allocation_rule(client, index_name, rule=None, **kwargs):
 
     :arg client: The Elasticsearch client connection
     :arg index_name: The index name
-    :arg rule: The routing allocation rule to apply, e.g. ``tag=ssd``.  Must be
+    :arg rule: The routing allocation rule to apply, e.g. ``tag=ssd``. Must be
         in the format of ``key=value``, and should match values declared on the
         correlating nodes in your cluster.
     """
@@ -589,6 +589,19 @@ def close_index(client, index_name, **kwargs):
     else:
         client.indices.flush(index=index_name)
         client.indices.close(index=index_name)
+
+### Open
+def open_index(client, index_name, **kwargs):
+    """
+    Open the indicated index.
+
+    :arg client: The Elasticsearch client connection
+    :arg index_name: The index name
+    """
+    if index_closed(client, index_name):
+        client.indices.open(index=index_name)
+    else:
+        logger.info('Skipping index {0}: Already open.'.format(index_name))
 
 ### Delete
 def delete_index(client, index_name, **kwargs):
@@ -960,6 +973,50 @@ def close(client, dry_run=False, **kwargs):
     matching_indices = filter_by_timestamp(object_list=index_list, **kwargs)
     _op_loop(client, matching_indices, op=close_index, dry_run=dry_run, **kwargs)
     logger.info(kwargs['prepend'] + 'Closed specified indices.')
+
+## curator open [ARGS]
+def open(client, dry_run=False, **kwargs):
+    """
+    Open indices ``older_than`` *n* ``time_unit``\s, matching the given
+    ``timestring``, ``prefix``, and ``suffix``.
+
+    .. note::
+       As this is an iterative function, default values are handled by the
+       target function(s).
+
+       Unless passed in `kwargs`, parameters other than ``client`` and
+       ``dry_run`` will have default values assigned by the functions being
+       called:
+
+       :py:func:`curator.curator.get_object_list`
+
+       :py:func:`curator.curator.filter_by_timestamp`
+
+       :py:func:`curator.curator.close_index`
+
+       These defaults are included here for documentation.
+
+    :arg client: The Elasticsearch client connection
+    :arg dry_run: If true, simulate, but do not perform the operation
+    :arg older_than: Indices older than the indicated number of whole
+        ``time_units`` will be operated on.
+    :arg time_unit: One of ``hours``, ``days``, ``weeks``, ``months``.  Default
+        is ``days``.
+    :arg timestring: An strftime string to match the datestamp in an index name.
+    :arg prefix: A string that comes before the datestamp in an index name.
+        Can be empty. Wildcards acceptable.  Default is ``logstash-``.
+    :arg suffix: A string that comes after the datestamp of an index name.
+        Can be empty. Wildcards acceptable.  Default is empty, ``''``.
+    :arg exclude_pattern: Exclude indices matching the provided regular
+        expression.
+    :arg utc_now: Used for testing.  Overrides current time with specified time.
+    """
+    kwargs['prepend'] = "DRY RUN:" if dry_run else ''
+    logging.info(kwargs['prepend'] + "Opening indices...")
+    index_list = get_object_list(client, **kwargs)
+    matching_indices = filter_by_timestamp(object_list=index_list, **kwargs)
+    _op_loop(client, matching_indices, op=open_index, dry_run=dry_run, **kwargs)
+    logger.info(kwargs['prepend'] + 'Opened specified indices.')
 
 ## curator delete [ARGS]
 def delete(client, dry_run=False, **kwargs):

--- a/curator/curator.py
+++ b/curator/curator.py
@@ -516,10 +516,11 @@ def apply_allocation_rule(client, index_name, rule=None, **kwargs):
 
     :arg client: The Elasticsearch client connection
     :arg index_name: The index name
-    :arg rule: The routing allocation rule to apply, e.g. ``tag=ssd``. Must be
-        in the format of ``key=value``, and should match values declared on the
-        correlating nodes in your cluster.
+    :arg rule: The routing allocation rule to apply, e.g. ``tag=ssd`` or ``shards_per_node=-1. Must be
+        in the format of ``key=value``. If key is ``tag``, it should match values declared on the
+        correlating nodes in your cluster. If key is ``shards_per_node`` the value should be -1 (default) or a value > 0.
     """
+    logger.error("apply_allocation_rule index=%s, args=%s", index_name, kwargs)
     if not rule:
         logger.error('No rule provided for {0}.'.format(index_name))
         return True
@@ -531,6 +532,24 @@ def apply_allocation_rule(client, index_name, rule=None, **kwargs):
     else:
         logger.info('Updating index setting index.routing.allocation.require.{0}={1}'.format(key,value))
         client.indices.put_settings(index=index_name, body='index.routing.allocation.require.{0}={1}'.format(key,value))
+
+### Shards Per Node
+def apply_shards_per_node(client, index_name, shards_per_node=-1, **kwargs):
+    """
+    Set total number of shards per node to an index.  See:
+    http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/index-modules-allocation.html#_total_shards_per_node
+
+    :arg client: The Elasticsearch client connection
+    :arg index_name: The index name
+    :arg shards_per_node: Number of shards per node. -1 is default (unbounded), other valid values are > 0.
+    """
+    if index_closed(client, index_name):
+        logger.info('Skipping index {0}: Already closed.'.format(index_name))
+        return True
+    else:
+        logger.info('Updating index setting index.routing.allocation.total_shards_per_node={0}'.format(shards_per_node))
+        client.indices.put_settings(index=index_name,
+              body='index.routing.allocation.total_shards_per_node={0}'.format(shards_per_node))
 
 ### Bloom
 def disable_bloom_filter(client, index_name, **kwargs):
@@ -882,6 +901,61 @@ def allocation(client, dry_run=False, **kwargs):
     matching_indices = filter_by_timestamp(object_list=index_list, **kwargs)
     _op_loop(client, matching_indices, op=apply_allocation_rule, dry_run=dry_run, **kwargs)
     logger.info(kwargs['prepend'] + 'Allocation/routing tags applied to specified indices.')
+
+
+## curator shardspernode
+def shards_per_node(client, dry_run=False, **kwargs):
+    """
+    Set total number of shards per node for indices ``older_than`` *n*
+    ``time_unit``\s, matching the given ``timestring``, ``prefix``, and
+    ``suffix`` by setting the provided values. Valid values are -1 (default,
+    unbounded), and values greater than zero. Zero is not valid.
+
+    .. note::
+       As this is an iterative function, default values are handled by the
+       target function(s).
+
+       Unless passed in `kwargs`, parameters other than ``client`` and
+       ``dry_run`` will have default values assigned by the functions being
+       called:
+
+       :py:func:`curator.curator.get_object_list`
+
+       :py:func:`curator.curator.filter_by_timestamp`
+
+       :py:func:`curator.curator.apply_shards_per_node`
+
+       These defaults are included here for documentation.
+
+    :arg client: The Elasticsearch client connection
+    :arg dry_run: If true, simulate, but do not perform the operation
+    :arg older_than: Indices older than the indicated number of whole
+        ``time_units`` will be operated on.
+    :arg time_unit: One of ``hours``, ``days``, ``weeks``, ``months``.  Default
+        is ``days``.
+    :arg timestring: An strftime string to match the datestamp in an index name.
+    :arg prefix: A string that comes before the datestamp in an index name.
+        Can be empty. Wildcards acceptable.  Default is ``logstash-``.
+    :arg suffix: A string that comes after the datestamp of an index name.
+        Can be empty. Wildcards acceptable.  Default is empty, ``''``.
+    :arg shards_per_node: The number shards per node. -1 or > 0.
+    :arg exclude_pattern: Exclude indices matching the provided regular
+        expression.
+    :arg utc_now: Used for testing.  Overrides current time with specified time.
+    """
+    kwargs['prepend'] = "DRY RUN: " if dry_run else ''
+    logging.info(kwargs['prepend'] + "Applying shards_per_node setting to indices...")
+
+    #sanity check
+    _s = kwargs['shards_per_node']
+    if _s < -1 or _s == 0:
+      logger.error("shards_per_node must be -1 or larger than zero.")
+      return
+    index_list = get_object_list(client, **kwargs)
+    matching_indices = filter_by_timestamp(object_list=index_list, **kwargs)
+    _op_loop(client, matching_indices, op=apply_shards_per_node, dry_run=dry_run, **kwargs)
+    logger.info(kwargs['prepend'] + 'Shards_per_node setting applied to specified indices.')
+
 
 ## curator bloom [ARGS]
 def bloom(client, dry_run=False, **kwargs):

--- a/curator/curator_script.py
+++ b/curator/curator_script.py
@@ -135,6 +135,12 @@ def make_parser():
     delete_group.add_argument('--older-than', help='Delete indices older than n TIME_UNITs', type=int)
     delete_group.add_argument('--disk-space', help='Delete indices beyond DISK_SPACE gigabytes.', type=float)
 
+    # Open
+    parser_open = subparsers.add_parser('open', help='Open indices')
+    parser_open.setdefaults(func=curator.open)
+    add_common_args(parser_open)
+    parser_open.add_argument('--older-than', required=True, help='Open indices older than n TIME_UNITs', type=int)
+
     # Optimize
     parser_optimize = subparsers.add_parser('optimize', help='Optimize indices')
     parser_optimize.set_defaults(func=curator.optimize)

--- a/curator/curator_script.py
+++ b/curator/curator_script.py
@@ -137,7 +137,7 @@ def make_parser():
 
     # Open
     parser_open = subparsers.add_parser('open', help='Open indices')
-    parser_open.setdefaults(func=curator.open)
+    parser_open.set_defaults(func=curator.open)
     add_common_args(parser_open)
     parser_open.add_argument('--older-than', required=True, help='Open indices older than n TIME_UNITs', type=int)
 
@@ -155,6 +155,13 @@ def make_parser():
     add_common_args(parser_replicas)
     parser_replicas.add_argument('--older-than', required=True, help='Change replica count for indices older than n TIME_UNITs', type=int)
     parser_replicas.add_argument('--count', dest='replicas', required=True, help='Number of replicas the indices should have', type=int, default=1)
+
+    # Shards per node
+    parser_shards_per_node = subparsers.add_parser('shardspernode', help='Set number of shards per node on indices')
+    parser_shards_per_node.set_defaults(func=curator.shards_per_node)
+    add_common_args(parser_shards_per_node)
+    parser_shards_per_node.add_argument('--older-than', required=True, help='set shards per node on indices older than n TIME_UNITs', type=int)
+    parser_shards_per_node.add_argument('--shards_per_node', help='Number of shards per node allowed', type=int)
 
     # Show indices
     parser_show = subparsers.add_parser('show', help='Show indices or snapshots')

--- a/test_curator/integration/test_utils.py
+++ b/test_curator/integration/test_utils.py
@@ -53,6 +53,37 @@ class TestCloseIndex(CuratorTestCase):
         )
         self.assertEquals('close', index_metadata['metadata']['indices']['test_index']['state'])
 
+class TestOpenIndex(CuratorTestCase):
+    def test_index_will_not_be_opened(self):
+        #don't open an already opened index.
+        self.create_index('test_index')
+        self.assertIsNone(curator.open_index(self.client, 'test_index'))
+        index_metadata = self.client.cluster.state(
+            index='test_index',
+            metric='metadata'
+        )
+        self.assertEquals('open', index_metadata['metadata']['indices']['test_index']['state'])
+
+    def test_close_open_index(self):
+        self.create_index('test_index')
+        self.assertIsNone(curator.close_index(self.client, 'test_index'))
+        #let's make sure it's closed.
+        index_metadata = self.client.cluster.state(
+            index='test_index',
+            metric='metadata',
+        )
+        self.assertEquals('close', index_metadata['metadata']['indices']['test_index']['state'])
+
+        #it's closed, now open it.
+        self.assertIsNone(curator.open_index(self.client, 'test_index'))
+        index_metadata = self.client.cluster.state(
+            index='test_index',
+            metric='metadata'
+        )
+        self.assertEquals('open', index_metadata['metadata']['indices']['test_index']['state'])
+
+
+
 class TestDeleteIndex(CuratorTestCase):
     def test_index_will_be_deleted(self):
         self.create_index('test_index')

--- a/test_curator/integration/test_utils.py
+++ b/test_curator/integration/test_utils.py
@@ -82,7 +82,11 @@ class TestOpenIndex(CuratorTestCase):
         )
         self.assertEquals('open', index_metadata['metadata']['indices']['test_index']['state'])
 
-
+class TestShardsPerNode(CuratorTestCase):
+    def test_set_shards_per_node(self):
+        self.create_index('logstash-2014.06.07')
+        self.assertIsNone(curator.shards_per_node(self.client, shards_per_node=-1, older_than=1,
+                                                  time_unit='days', prefix='logstash', timestring='%%Y.%%m.%%d'))
 
 class TestDeleteIndex(CuratorTestCase):
     def test_index_will_be_deleted(self):


### PR DESCRIPTION
Add functionality to open indices to compliment the close option.

Add functionality to set the number of shards per node for an index. We require this to rebalance our cluster fairly regularly, and hopefully it's useful to others as well.

