### PR TITLE
V3.0.0b3 release

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -3,8 +3,27 @@
 Changelog
 =========
 
-3.0.0 (? ? ?)
--------------
+3.0.0b3 (4 March 2015)
+--------------------------
+
+**Bug fixes**
+
+ * setup.py was lacking the new packages "curator.api" and "curator.cli"  The
+   package works now.
+ * Python3 suggested I had to normalize the beta tag to just b3, so that's also
+   changed.
+ * Cleaned out superfluous imports and logger references from the __init__.py
+   files.
+
+3.0.0-beta2 (3 March 2015)
+--------------------------
+
+**Bug fixes**
+
+ * Python3 issues resolved.  Tests now pass on both Python2 and Python3
+
+3.0.0-beta1 (3 March 2015)
+--------------------------
 
 **General**
 

--- a/curator/__init__.py
+++ b/curator/__init__.py
@@ -1,6 +1,3 @@
 from ._version import __version__
 from .api import *
 from .cli import *
-
-import logging
-logger = logging.getLogger(__name__)

--- a/curator/_version.py
+++ b/curator/_version.py
@@ -1,1 +1,1 @@
-__version__ = '3.0.0-beta3'
+__version__ = '3.0.0b3'

--- a/curator/api/__init__.py
+++ b/curator/api/__init__.py
@@ -1,8 +1,3 @@
-import logging
-import elasticsearch
-
-logger = logging.getLogger(__name__)
-
 from .utils import *
 from .filter import *
 from .alias import *

--- a/curator/cli/__init__.py
+++ b/curator/cli/__init__.py
@@ -1,7 +1,3 @@
-import logging
-logger = logging.getLogger(__name__)
-
-from ..api import *
 from .utils import *
 from .cli import *
 from .alias import *

--- a/curator/curator.py
+++ b/curator/curator.py
@@ -1,8 +1,5 @@
 import click
 from .cli import cli
 
-import logging
-logger = logging.getLogger(__name__)
-
 def main():
     cli( obj={ "filters": [] } )

--- a/curator/es_repo_mgr.py
+++ b/curator/es_repo_mgr.py
@@ -1,8 +1,5 @@
 import click
 from .cli import es_repo_mgr
 
-import logging
-logger = logging.getLogger(__name__)
-
 def main():
     es_repo_mgr.repomgrcli()

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     license = "Apache License, Version 2.0",
     install_requires = get_install_requires(),
     keywords = "elasticsearch time-series indexed index-expiry",
-    packages = ["curator"],
+    packages = ["curator", "curator.api", "curator.cli"],
     include_package_data=True,
     entry_points = {
         "console_scripts" : ["curator = curator.curator:main",


### PR DESCRIPTION
## Bugfix update

* setup.py was lacking the new packages "curator.api" and "curator.cli"  The package works now.
* Python3 suggested I had to normalize the beta tag to just b3, so that's also changed.
* Cleaned out superfluous imports and logger references from the __init__.py files.