### PR TITLE
Allow allocation and replicas operations for closed indices

### DIFF
--- a/curator/api/allocation.py
+++ b/curator/api/allocation.py
@@ -6,7 +6,6 @@ logger = logging.getLogger(__name__)
 def apply_allocation_rule(client, indices, rule=None):
     """
     Apply a required allocation rule to a list of indices.
-    This method will ignore closed indices.
 
     :arg client: The Elasticsearch client connection
     :arg indices: A list of indices to act on

--- a/curator/api/replicas.py
+++ b/curator/api/replicas.py
@@ -6,7 +6,6 @@ logger = logging.getLogger(__name__)
 def change_replicas(client, indices, replicas=None):
     """
     Change the number of replicas, more or less, for the indicated indices.
-    This method will ignore closed indices.
 
     :arg client: The Elasticsearch client connection
     :arg indices: A list of indices to act on
@@ -17,7 +16,7 @@ def change_replicas(client, indices, replicas=None):
         logger.error('No replica count provided.')
         return False
     else:
-        indices = prune_closed(client, indices)
+        indices = ensure_list(indices)
         logger.info('Updating index setting: number_of_replicas={0}'.format(replicas))
         try:
             client.indices.put_settings(index=to_csv(indices),

--- a/curator/api/utils.py
+++ b/curator/api/utils.py
@@ -272,7 +272,7 @@ def prune_allocated(client, indices, key, value):
     :arg value: The value to check for
     :rtype: list
     """
-    indices = prune_closed(client, indices)
+    indices = ensure_list(indices)
     retval = []
     for idx in indices:
         settings = client.indices.get_settings(

--- a/test/integration/test_api_commands.py
+++ b/test/integration/test_api_commands.py
@@ -102,6 +102,31 @@ class TestChangeReplicas(CuratorTestCase):
 
         self.assertEquals('0', self.client.indices.get_settings(index='test_index')['test_index']['settings']['index']['number_of_replicas'])
 
+    def test_closed_index_replicas_can_be_modified(self):
+        self.create_index('test_index')
+
+        self.client.indices.close(index='test_index')
+        index_metadata = self.client.cluster.state(
+            index='test_index',
+            metric='metadata',
+        )
+        self.assertEquals('close', index_metadata['metadata']['indices']['test_index']['state'])
+
+        self.assertEquals('0', self.client.indices.get_settings(index='test_index')['test_index']['settings']['index']['number_of_replicas'])
+
+        curator.change_replicas(self.client, 'test_index', replicas=1)
+
+        self.assertEquals('1', self.client.indices.get_settings(index='test_index')['test_index']['settings']['index']['number_of_replicas'])
+
+        self.client.indices.open(index='test_index')
+        index_metadata = self.client.cluster.state(
+            index='test_index',
+            metric='metadata',
+        )
+        self.assertEquals('open', index_metadata['metadata']['indices']['test_index']['state'])
+
+        self.assertEquals('1', self.client.indices.get_settings(index='test_index')['test_index']['settings']['index']['number_of_replicas'])
+ 
 class TestChangeAllocation(CuratorTestCase):
     def test_index_allocation_can_be_modified(self):
         self.create_index('test_index')

--- a/test/integration/test_api_commands.py
+++ b/test/integration/test_api_commands.py
@@ -102,6 +102,37 @@ class TestChangeReplicas(CuratorTestCase):
 
         self.assertEquals('0', self.client.indices.get_settings(index='test_index')['test_index']['settings']['index']['number_of_replicas'])
 
+class TestChangeAllocation(CuratorTestCase):
+    def test_index_allocation_can_be_modified(self):
+        self.create_index('test_index')
+
+        curator.apply_allocation_rule(self.client, 'test_index', rule="key=value")
+
+        self.assertEquals('value', self.client.indices.get_settings(index='test_index')['test_index']['settings']['index']['routing']['allocation']['require']['key'])
+
+    def test_closed_index_allocation_can_be_modified(self):
+        self.create_index('test_index')
+
+        self.client.indices.close(index='test_index')
+        index_metadata = self.client.cluster.state(
+            index='test_index',
+            metric='metadata',
+        )
+        self.assertEquals('close', index_metadata['metadata']['indices']['test_index']['state'])
+
+        curator.apply_allocation_rule(self.client, 'test_index', rule="key=value")
+
+        self.assertEquals('value', self.client.indices.get_settings(index='test_index')['test_index']['settings']['index']['routing']['allocation']['require']['key'])
+
+        self.client.indices.open(index='test_index')
+        index_metadata = self.client.cluster.state(
+            index='test_index',
+            metric='metadata',
+        )
+        self.assertEquals('open', index_metadata['metadata']['indices']['test_index']['state'])
+
+        self.assertEquals('value', self.client.indices.get_settings(index='test_index')['test_index']['settings']['index']['routing']['allocation']['require']['key'])
+
 class TestDeleteIndex(CuratorTestCase):
     def test_index_will_be_deleted(self):
         self.create_index('test_index')


### PR DESCRIPTION
This is an attempt to fix #279. @untergeek: could you please review the changes? Especially the test for changing the replica count of a closed index, as it seems to be already possible without any code change despite calling `prune_closed` (but maybe it's just late and it's not a bug :) So I omitted changing this [`prune_closed`](https://github.com/elasticsearch/curator/blob/master/curator/api/replicas.py#L20) to `ensure_list` for now, but I agree that it would be proper to change that.

ps.: I also think that adding a `prune_replicated` function would be useful to skip the indices that already has the requested replica count (as it is slow to forcibly apply it). I can send a separate PR for that, but since its implementation would probably be related to this changeset, I guess it's a good idea to get this done first.