### PR TITLE
Beta4 updates

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -3,8 +3,26 @@
 Changelog
 =========
 
+3.0.0b4 (5 March 2015)
+----------------------
+
+**Notes**
+
+Integration testing!  Because I finally figured out how to use the Click
+Testing API, I now have a good collection of command-line simulations,
+complete with a real back-end.  This testing found a few bugs (this is why
+testing exists, right?), and fixed a few of them.
+
+**Bug fixes**
+
+ * HUGE! `curator show snapshots` would _delete_ snapshots.  This is fixed.
+ * Return values are now being sent from the commands.
+ * `scripttest` is no longer necessary (click.Test works!)
+ * Calling `get_snapshot` without a snapshot name returns all snapshots
+ 
+
 3.0.0b3 (4 March 2015)
---------------------------
+----------------------
 
 **Bug fixes**
 

--- a/curator/api/snapshot.py
+++ b/curator/api/snapshot.py
@@ -83,6 +83,6 @@ def delete_snapshot(client, snapshot=None, repository=None):
     try:
         client.snapshot.delete(repository=repository, snapshot=snapshot)
         return True
-    except elasticsearch.RequestError as e:
+    except elasticsearch.RequestError:
         logger.error("Unable to delete snapshot {0} from repository {1}.  Check logs for more information.".format(snapshot, repository))
         return False

--- a/curator/api/utils.py
+++ b/curator/api/utils.py
@@ -171,9 +171,6 @@ def get_snapshot(client, repository='', snapshot=''):
     if not repository:
         logger.error('Missing required repository parameter')
         return False
-    if not snapshot:
-        logger.error('Missing required snapshot parameter')
-        return False
     try:
         return client.snapshot.get(repository=repository, snapshot=snapshot)
     except (elasticsearch.TransportError, elasticsearch.NotFoundError):

--- a/curator/cli/bloom.py
+++ b/curator/cli/bloom.py
@@ -7,9 +7,6 @@ logger = logging.getLogger(__name__)
 @cli.group('bloom')
 @click.option('--delay', type=int, default=0, show_default=True, expose_value=True,
             help='Pause *n* seconds after disabling bloom filter cache of an index')
-@click.option('--request_timeout', type=int, default=218600, show_default=True,
-            expose_value=True,
-            help='Allow this many seconds before the transaction times out.')
 @click.pass_context
 def bloom(ctx, delay):
     """Disable bloom filter cache"""

--- a/curator/cli/cli.py
+++ b/curator/cli/cli.py
@@ -73,8 +73,8 @@ def cli(ctx, host, url_prefix, port, use_ssl, http_auth, timeout, master_only, d
             handler.addFilter(
                 Whitelist(
                     'root', '__main__', 'curator', 'curator.curator',
-                    'curator.api', 'curator.cli', 'curator.curator.api',
-                    'curator.curator.cli'
+                    'curator.api', 'curator.cli', 'curator.api',
+                    'curator.cli'
                 )
             )
 

--- a/curator/cli/index_selection.py
+++ b/curator/cli/index_selection.py
@@ -63,7 +63,7 @@ def indices(ctx, newer_than, older_than, prefix, suffix, time_unit,
         if indices:
             working_list = indices
         else:
-            click.echo(click.style('ERROR. Unable to get indices from Elasticsearch.', fg='red', bold=True))
+            click.echo(click.style('ERROR. No indices found in Elasticsearch.', fg='red', bold=True))
             sys.exit(1)
 
     if all_indices:
@@ -73,7 +73,7 @@ def indices(ctx, newer_than, older_than, prefix, suffix, time_unit,
     logger.debug('All filters: {0}'.format(ctx.obj['filters']))
 
     for f in ctx.obj['filters']:
-        if all_indices and not f['exclude']:
+        if all_indices and not 'exclude' in f:
             continue
         logger.debug('Filter: {0}'.format(f))
         working_list = regex_iterate(working_list, **f)
@@ -99,12 +99,8 @@ def indices(ctx, newer_than, older_than, prefix, suffix, time_unit,
                 logging.info("The following indices would have been altered:")
                 show(working_list)
             else:
-                try:
-                    retval = do_command(client, ctx.parent.info_name, working_list, ctx.parent.params)
-                    sys.exit(0) if retval else sys.exit(1)
-                except Exception as e:
-                    logger.error("Unable to complete: {0}  Exception: {1}".format(ctx.parent.info_name, e.message))
-                    sys.exit(1)
+                retval = do_command(client, ctx.parent.info_name, working_list, ctx.parent.params)
+                sys.exit(0) if retval else sys.exit(1)
 
     else:
         logger.warn('No indices matched provided args.')

--- a/curator/cli/utils.py
+++ b/curator/cli/utils.py
@@ -155,35 +155,36 @@ def do_command(client, command, indices, params=None):
     Do the command.
     """
     if command == "alias":
-        alias(client, indices, alias=params['name'], remove=params['remove'])
+        return alias(
+                client, indices, alias=params['name'], remove=params['remove']
+               )
     if command == "allocation":
-        allocation(client, indices, rule=params['rule'])
+        return allocation(client, indices, rule=params['rule'])
     if command == "bloom":
-        bloom(client, indices, delay=params['delay'])
+        return bloom(client, indices, delay=params['delay'])
     if command == "close":
-        close(client, indices)
+        return close(client, indices)
     if command == "delete":
-        click.echo("params = {0}, indices = {1}".format(params, indices))
-        delete(
-            client, indices, disk_space=params['disk_space'],
-            reverse=params['reverse']
-        )
+        return delete(
+                client, indices, disk_space=params['disk_space'],
+                reverse=params['reverse']
+               )
     if command == "open":
-        opener(client, indices)
+        return opener(client, indices)
     if command == "optimize":
-        optimize(
-            client, indices, max_num_segments=params['max_num_segments'],
-            delay=params['delay'], request_timeout=params['request_timeout']
-        )
+        return optimize(
+                client, indices, max_num_segments=params['max_num_segments'],
+                delay=params['delay'], request_timeout=params['request_timeout']
+               )
     if command == "replicas":
-        replicas(client, indices, replicas=params['count'])
+        return replicas(client, indices, replicas=params['count'])
     if command == "snapshot":
-        create_snapshot(
-            client, indices=indices, name=params['name'],
-            prefix=params['prefix'], repository=params['repository'],
-            ignore_unavailable=params['ignore_unavailable'],
-            include_global_state=params['include_global_state'],
-            partial=params['partial'],
-            wait_for_completion=params['wait_for_completion'],
-            request_timeout=params['request_timeout'],
-        )
+        return create_snapshot(
+                client, indices=indices, name=params['name'],
+                prefix=params['prefix'], repository=params['repository'],
+                ignore_unavailable=params['ignore_unavailable'],
+                include_global_state=params['include_global_state'],
+                partial=params['partial'],
+                wait_for_completion=params['wait_for_completion'],
+                request_timeout=params['request_timeout'],
+               )

--- a/setup.py
+++ b/setup.py
@@ -50,5 +50,5 @@ setup(
         "License :: OSI Approved :: Apache Software License",
     ],
     test_suite = "test.run_tests.run_all",
-    tests_require = ["mock", "nose", "coverage", "nosexcover", "scripttest"]
+    tests_require = ["mock", "nose", "coverage", "nosexcover"]
 )

--- a/test/integration/test_api_commands.py
+++ b/test/integration/test_api_commands.py
@@ -126,7 +126,7 @@ class TestChangeReplicas(CuratorTestCase):
         self.assertEquals('open', index_metadata['metadata']['indices']['test_index']['state'])
 
         self.assertEquals('1', self.client.indices.get_settings(index='test_index')['test_index']['settings']['index']['number_of_replicas'])
- 
+
 class TestChangeAllocation(CuratorTestCase):
     def test_index_allocation_can_be_modified(self):
         self.create_index('test_index')
@@ -191,13 +191,3 @@ class TestOptimizeIndex(CuratorTestCase):
         self.client.create(index='test_index', doc_type='log', body={'message':'TEST DOCUMENT'})
         # Will only have 1 segment
         self.assertTrue(curator.optimize_index(self.client, 'test_index', max_num_segments=4))
-
-    # def test_unoptimized_index_will_be_optimized(self):
-    #     self.create_index('test_index')
-    #     for i in range(1, 11):
-    #         self.client.create(index='test_index', doc_type='log' + str(i), body={'message':'TEST DOCUMENT'})
-    #         curator.optimize(self.client, "test_index", max_num_segments=10, delay=1)
-    #     # Make sure we have more than 4 segments before the optimize
-    #     self.assertGreater(curator.get_segmentcount(self.client, "test_index")[1], 4 )
-    #     self.assertTrue(curator.optimize_index(self.client, 'test_index', max_num_segments=1))
-    #     self.assertEqual(1, curator.get_segmentcount(self.client, "test_index")[1] )

--- a/test/integration/test_cli_commands.py
+++ b/test/integration/test_cli_commands.py
@@ -4,7 +4,6 @@ import os
 import click
 from click import testing as clicktest
 from mock import patch, Mock
-from scripttest import TestFileEnvironment
 
 from . import CuratorTestCase
 
@@ -25,45 +24,710 @@ class TestGetClient(CuratorTestCase):
             curator.get_client(**client_args)
         self.assertEqual(cm.exception.code, 1)
 
+class TestCLIIndexSelection(CuratorTestCase):
+    def test_index_selection_only_timestamp_filter(self):
+        self.create_indices(10)
+        indices = curator.get_indices(self.client)
+        expected = sorted(indices, reverse=True)[:4]
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'indices',
+                        '--timestring', '%Y.%m.%d',
+                    ],
+                    obj={"filters":[]})
+        output = sorted(result.output.splitlines(), reverse=True)[:4]
+        self.assertEqual(expected, output)
+    def test_index_selection_no_filters(self):
+        self.create_indices(1)
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'indices',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(1, result.exit_code)
+    def test_index_selection_manual_selection_single(self):
+        self.create_index('my_index')
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'indices',
+                        '--index', 'my_index',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(['my_index'], result.output.splitlines()[:1])
+    def test_index_selection_no_indices_test(self):
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'indices',
+                        '--all-indices',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(1, result.exit_code)
+    def test_index_selection_all_indices_single(self):
+        self.create_index('my_index')
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'indices',
+                        '--all-indices',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(['my_index'], result.output.splitlines()[:1])
+    def test_index_selection_all_indices_exclude(self):
+        self.create_index('my_index')
+        self.create_index('your_index')
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'indices',
+                        '--all-indices',
+                        '--exclude', '^your.*$',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(['my_index'], result.output.splitlines()[:1])
+    def test_index_selection_regex_match(self):
+        self.create_index('my_index')
+        self.create_index('your_index')
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'indices',
+                        '--regex', '^my.*$',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(['my_index'], result.output.splitlines()[:1])
+    def test_index_selection_all_indices_skip_non_exclude_filters(self):
+        self.create_index('my_index')
+        self.create_index('your_index')
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'indices',
+                        '--all-indices',
+                        '--suffix', 'index',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(['my_index', 'your_index'], result.output.splitlines()[:2])
+    def test_cli_show_indices_if_dry_run(self):
+        self.create_indices(10)
+        indices = curator.get_indices(self.client)
+        expected = sorted(indices, reverse=True)[:4]
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--dry-run',
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'alias', '--name', 'dummy_alias',
+                        'indices',
+                        '--newer-than', '5',
+                        '--timestring', '%Y.%m.%d',
+                        '--time-unit', 'days'
+                    ],
+                    obj={"filters":[]})
+        output = sorted(result.output.splitlines(), reverse=True)[:4]
+        self.assertEqual(expected, output)
+    def test_cli_no_indices_after_filtering(self):
+        self.create_indices(10)
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'indices',
+                        '--exclude', 'log',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(99, result.exit_code)
+
+class TestCLIAlias(CuratorTestCase):
+    def test_alias_no_name_param(self):
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'alias',
+                        'indices',
+                        '--exclude', 'log',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(1, result.exit_code)
+    def test_alias_all_indices_single(self):
+        self.create_index('my_index')
+        alias = 'testalias'
+        self.create_index('dummy')
+        self.client.indices.put_alias(index='dummy', name=alias)
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'alias', '--name', alias,
+                        'indices',
+                        '--all-indices',
+                    ],
+                    obj={"filters":[]})
+        self.assertEquals(2, len(self.client.indices.get_alias(name=alias)))
+
+class TestCLIAllocation(CuratorTestCase):
+    def test_allocation_no_rule_param(self):
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'allocation',
+                        'indices',
+                        '--exclude', 'log',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(1, result.exit_code)
+    def test_allocation_all_indices_single(self):
+        self.create_index('my_index')
+        key = 'foo'
+        value = 'bar'
+        rule = key + '=' + value
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'allocation', '--rule', rule,
+                        'indices',
+                        '--all-indices',
+                    ],
+                    obj={"filters":[]})
+        self.assertEquals(
+            value,
+            self.client.indices.get_settings(index='my_index')['my_index']['settings']['index']['routing']['allocation']['require'][key]
+        )
+
+class TestCLIBloom(CuratorTestCase):
+    def test_bloom_cli(self):
+        self.create_indices(5)
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'bloom',
+                        'indices',
+                        '--all-indices',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(0, result.exit_code)
+
+class TestCLIClose(CuratorTestCase):
+    def test_close_cli(self):
+        self.create_indices(5)
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'close',
+                        'indices',
+                        '--all-indices',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(0, result.exit_code)
+
+class TestCLIDelete(CuratorTestCase):
+    def test_delete_indics_skip_kibana(self):
+        self.create_index('my_index')
+        self.create_index('.kibana')
+        self.create_index('kibana-int')
+        self.create_index('.marvel-kibana')
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'delete',
+                        'indices',
+                        '--all-indices',
+                    ],
+                    obj={"filters":[]})
+        l = curator.get_indices(self.client)
+        self.assertEqual(sorted(['.kibana', '.marvel-kibana', 'kibana-int']), sorted(l))
+
+class TestCLIOpen(CuratorTestCase):
+    def test_open_cli(self):
+        self.create_indices(5)
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'open',
+                        'indices',
+                        '--all-indices',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(0, result.exit_code)
+
+class TestCLIOptimize(CuratorTestCase):
+    def test_optimize_cli(self):
+        self.create_indices(5)
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'optimize',
+                        'indices',
+                        '--all-indices',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(0, result.exit_code)
+
+class TestCLIReplicas(CuratorTestCase):
+    def test_replicas_no_count_param(self):
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'replicas',
+                        'indices',
+                        '--exclude', 'log',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(1, result.exit_code)
+    def test_replicas_cli(self):
+        self.create_indices(5)
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'replicas', '--count', '2',
+                        'indices',
+                        '--all-indices',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(0, result.exit_code)
+
 class TestCLIShow(CuratorTestCase):
     def test_cli_show_indices(self):
         self.create_indices(10)
         indices = curator.get_indices(self.client)
         expected = sorted(indices, reverse=True)[:4]
-        env = TestFileEnvironment('./scratch')
-        script = os.path.join(os.path.dirname(__file__), '../../run_curator.py')
-        result = env.run("python " + script + " --logfile /dev/null --host " + host + " --port " + str(port) + " show indices --newer-than 5 --timestring '%Y.%m.%d' --time-unit days")
-        output = sorted(result.stdout.splitlines(), reverse=True)
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'indices',
+                        '--newer-than', '5',
+                        '--timestring', '%Y.%m.%d',
+                        '--time-unit', 'days'
+                    ],
+                    obj={"filters":[]})
+        output = sorted(result.output.splitlines(), reverse=True)[:4]
         self.assertEqual(expected, output)
 
-class TestCLIAlias(CuratorTestCase):
-    def test_cli_alias_fail(self):
-        # Testing for failure because --name is omitted.  An exit code of 1 is validated.
-        env = TestFileEnvironment('./scratch')
-        script = os.path.join(os.path.dirname(__file__), '../../run_curator.py')
-        result = env.run("python " + script + " --logfile /dev/null --host " + host + " --port " + str(port) + " alias indices --newer-than 5 --timestring '%Y.%m.%d' --time-unit days", expect_error=True)
-        self.assertEqual(1, result.returncode)
-
-class TestCLIAllocate(CuratorTestCase):
-    def test_cli_allocate_fail(self):
-        # Testing for failure because --rule is omitted.  An exit code of 1 is validated.
-        env = TestFileEnvironment('./scratch')
-        script = os.path.join(os.path.dirname(__file__), '../../run_curator.py')
-        result = env.run("python " + script + " --logfile /dev/null --host " + host + " --port " + str(port) + " allocation indices --newer-than 5 --timestring '%Y.%m.%d' --time-unit days", expect_error=True)
-        self.assertEqual(1, result.returncode)
-
-class TestCLIReplicas(CuratorTestCase):
-    def test_cli_replicas_fail(self):
-        # Testing for failure because --count is omitted.  An exit code of 1 is validated.
-        env = TestFileEnvironment('./scratch')
-        script = os.path.join(os.path.dirname(__file__), '../../run_curator.py')
-        result = env.run("python " + script + " --logfile /dev/null --host " + host + " --port " + str(port) + " replicas indices --newer-than 5 --timestring '%Y.%m.%d' --time-unit days", expect_error=True)
-        self.assertEqual(1, result.returncode)
-
 class TestCLISnapshot(CuratorTestCase):
-    def test_cli_snapshot_fail(self):
-        # Testing for failure because --repository is omitted.  An exit code of 1 is validated.
-        env = TestFileEnvironment('./scratch')
-        script = os.path.join(os.path.dirname(__file__), '../../run_curator.py')
-        result = env.run("python " + script + " --logfile /dev/null --host " + host + " --port " + str(port) + " snapshot indices --newer-than 5 --timestring '%Y.%m.%d' --time-unit days", expect_error=True)
-        self.assertEqual(1, result.returncode)
+    def test_snapshot_no_repository_param(self):
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'snapshot',
+                        'indices',
+                        '--exclude', 'log',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(1, result.exit_code)
+    def test_cli_snapshot_indices(self):
+        self.create_indices(5)
+        self.create_repository()
+        snap_name = 'snapshot1'
+        indices = curator.get_indices(self.client)
+        expected = sorted(indices, reverse=True)[:4]
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'snapshot',
+                        '--repository', self.args['repository'],
+                        '--name', snap_name,
+                        'indices',
+                        '--all-indices',
+                    ],
+                    obj={"filters":[]})
+        snapshot = curator.get_snapshot(
+                    self.client, self.args['repository'], '_all'
+                   )
+        self.assertEqual(1, len(snapshot['snapshots']))
+        self.assertEqual(snap_name, snapshot['snapshots'][0]['snapshot'])
+
+
+class TestCLISnapshotSelection(CuratorTestCase):
+    def test_show_no_repository_param(self):
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'snapshots',
+                        '--exclude', 'log',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(1, result.exit_code)
+    def test_snapshot_selection_show_all_snapshots(self):
+        index_name = 'index1'
+        snap_name = 'snapshot1'
+        self.create_index(index_name)
+        self.create_repository()
+        self.client.create(
+            index=index_name, doc_type='log', body={'message':'TEST DOCUMENT'}
+            )
+        curator.create_snapshot(
+            self.client, name=snap_name, indices=index_name,
+            repository=self.args['repository']
+            )
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'snapshots',
+                        '--repository', self.args['repository'],
+                        '--all-snapshots',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual([snap_name], result.output.splitlines()[:1])
+    def test_snapshot_selection_show_all_snapshots_with_exclude(self):
+        self.create_repository()
+        for i in ["1", "2"]:
+            self.create_index("index" + i)
+            self.client.create(
+                index="index" + i, doc_type='log',
+                body={'message':'TEST DOCUMENT'},
+            )
+            curator.create_snapshot(
+                self.client, name="snapshot" + i, indices="index" + i,
+                repository=self.args['repository']
+            )
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'snapshots',
+                        '--repository', self.args['repository'],
+                        '--all-snapshots',
+                        '--exclude', '2',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(['snapshot1'], result.output.splitlines()[:1])
+    def test_snapshot_selection_no_snapshots_found(self):
+        self.create_repository()
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'snapshots',
+                        '--repository', self.args['repository'],
+                        '--all-snapshots',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(1, result.exit_code)
+    def test_snapshot_selection_show_filtered(self):
+        self.create_repository()
+        for i in ["1", "2", "3"]:
+            self.create_index("index" + i)
+            self.client.create(
+                index="index" + i, doc_type='log',
+                body={'message':'TEST DOCUMENT'},
+            )
+            curator.create_snapshot(
+                self.client, name="snapshot" + i, indices="index" + i,
+                repository=self.args['repository']
+            )
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'snapshots',
+                        '--repository', self.args['repository'],
+                        '--prefix', 'snap',
+                        '--suffix', '1',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(['snapshot1'], result.output.splitlines()[:1])
+    def test_snapshot_selection_show_all_snapshots_with_exclude_and_other(self):
+        self.create_repository()
+        for i in ["1", "2"]:
+            self.create_index("index" + i)
+            self.client.create(
+                index="index" + i, doc_type='log',
+                body={'message':'TEST DOCUMENT'},
+            )
+            curator.create_snapshot(
+                self.client, name="snapshot" + i, indices="index" + i,
+                repository=self.args['repository']
+            )
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'snapshots',
+                        '--repository', self.args['repository'],
+                        '--all-snapshots',
+                        '--exclude', '2',
+                        '--prefix', 'missing',
+                        '--suffix', 'also_missing',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(['snapshot1'], result.output.splitlines()[:1])
+    def test_snapshot_selection_delete_all_snapshots_with_dry_run(self):
+        self.create_repository()
+        for i in ["1", "2"]:
+            self.create_index("index" + i)
+            self.client.create(
+                index="index" + i, doc_type='log',
+                body={'message':'TEST DOCUMENT'},
+            )
+            curator.create_snapshot(
+                self.client, name="snapshot" + i, indices="index" + i,
+                repository=self.args['repository']
+            )
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--dry-run',
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'delete',
+                        'snapshots',
+                        '--repository', self.args['repository'],
+                        '--all-snapshots',
+                        '--exclude', '2',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(['snapshot1'], result.output.splitlines()[:1])
+    def test_snapshot_selection_delete_snapshot(self):
+        self.create_repository()
+        for i in ["1", "2"]:
+            self.create_index("index" + i)
+            self.client.create(
+                index="index" + i, doc_type='log',
+                body={'message':'TEST DOCUMENT'},
+            )
+            curator.create_snapshot(
+                self.client, name="snapshot" + i, indices="index" + i,
+                repository=self.args['repository']
+            )
+        result = curator.get_snapshot(self.client, self.args['repository'], '_all')
+        self.assertEqual(2, len(result['snapshots']))
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'delete',
+                        'snapshots',
+                        '--repository', self.args['repository'],
+                        '--exclude', '2',
+                    ],
+                    obj={"filters":[]})
+        result = curator.get_snapshot(self.client, self.args['repository'], '_all')
+        self.assertEqual(1, len(result['snapshots']))
+        self.assertEqual('snapshot2', result['snapshots'][0]['snapshot'])
+    def test_snapshot_selection_all_filtered_fail(self):
+        self.create_repository()
+        for i in ["1", "2", "3"]:
+            self.create_index("index" + i)
+            self.client.create(
+                index="index" + i, doc_type='log',
+                body={'message':'TEST DOCUMENT'},
+            )
+            curator.create_snapshot(
+                self.client, name="snapshot" + i, indices="index" + i,
+                repository=self.args['repository']
+            )
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'snapshots',
+                        '--repository', self.args['repository'],
+                        '--prefix', 'no_match',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(99, result.exit_code)
+
+class TestCLILogging(CuratorTestCase):
+    def test_logging_with_debug_flag(self):
+        self.create_indices(10)
+        indices = curator.get_indices(self.client)
+        expected = sorted(indices, reverse=True)[:4]
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--debug',
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'indices',
+                        '--newer-than', '5',
+                        '--timestring', '%Y.%m.%d',
+                        '--time-unit', 'days'
+                    ],
+                    obj={"filters":[]})
+        output = sorted(result.output.splitlines(), reverse=True)[:4]
+        self.assertEqual(expected, output)
+
+    def test_logging_with_bad_loglevel_flag(self):
+        self.create_indices(1)
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--loglevel', 'FOO',
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'indices',
+                        '--newer-than', '5',
+                        '--timestring', '%Y.%m.%d',
+                        '--time-unit', 'days'
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual('Invalid log level: FOO', str(result.exception))
+
+    def test_logging_with_logformat_logstash_flag(self):
+        self.create_indices(10)
+        indices = curator.get_indices(self.client)
+        expected = sorted(indices, reverse=True)[:4]
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logformat', 'logstash',
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'indices',
+                        '--newer-than', '5',
+                        '--timestring', '%Y.%m.%d',
+                        '--time-unit', 'days'
+                    ],
+                    obj={"filters":[]})
+        output = sorted(result.output.splitlines(), reverse=True)[:4]
+        self.assertEqual(expected, output)

--- a/test/integration/test_cli_utils.py
+++ b/test/integration/test_cli_utils.py
@@ -23,3 +23,36 @@ class TestGetClient(CuratorTestCase):
         with self.assertRaises(SystemExit) as cm:
             curator.get_client(**client_args)
         self.assertEqual(cm.exception.code, 1)
+
+class TestCLIUtilsFilterCallback(CuratorTestCase):
+    def test_filter_callback_without_timestring(self):
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'indices',
+                        '--older-than', '5',
+                        '--time-unit', 'days',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(1, result.exit_code)
+    def test_filter_callback_without_timeunit(self):
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'indices',
+                        '--newer-than', '5',
+                        '--timestring', '%Y.%m.%d',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(1, result.exit_code)
+    

--- a/test/unit/test_api_utils.py
+++ b/test/unit/test_api_utils.py
@@ -226,9 +226,6 @@ class TestGetSnapshot(TestCase):
     def test_get_snapshot_missing_repository_arg(self):
         client = Mock()
         self.assertFalse(curator.get_snapshot(client, snapshot=snap_name))
-    def test_get_snapshot_missing_snapshot_arg(self):
-        client = Mock()
-        self.assertFalse(curator.get_snapshot(client, repository=repo_name))
     def test_get_snapshot_positive(self):
         client = Mock()
         client.snapshot.get.return_value = snapshot


### PR DESCRIPTION
3.0.0b4 (5 March 2015)
----------------------

**Notes**

Integration testing!  Because I finally figured out how to use the Click
Testing API, I now have a good collection of command-line simulations,
complete with a real back-end.  This testing found a few bugs (this is why
testing exists, right?), and fixed a few of them.

**Bug fixes**

 * HUGE! `curator show snapshots` would _delete_ snapshots.  This is fixed.
 * Return values are now being sent from the commands.
 * `scripttest` is no longer necessary (click.Test works!)
 * Calling `get_snapshot` without a snapshot name returns all snapshots