### PR TITLE
Integration testing across ES versions found a bug

### DIFF
--- a/curator/_version.py
+++ b/curator/_version.py
@@ -1,1 +1,1 @@
-__version__ = '3.0.0rc1'
+__version__ = '3.0.0rc2'

--- a/curator/api/snapshot.py
+++ b/curator/api/snapshot.py
@@ -39,12 +39,15 @@ def create_snapshot(client, indices='_all', name=None,
     if not indices:
         logger.error("No indices provided.")
         return False
-    try:
-        nodes = client.snapshot.verify_repository(repository=repository)['nodes']
-        logger.debug('Nodes with verified repository access: {0}'.format(nodes))
-    except Exception:
-        logger.error('Failed to verify all nodes have repository access.')
-        return False
+    repo_access = (1, 4, 0)
+    version_number = get_version(client)
+    if version_number >= repo_access:
+        try:
+            nodes = client.snapshot.verify_repository(repository=repository)['nodes']
+            logger.debug('Nodes with verified repository access: {0}'.format(nodes))
+        except Exception:
+            logger.error('Failed to verify all nodes have repository access.')
+            return False
     body=create_snapshot_body(indices, ignore_unavailable=ignore_unavailable,
                                 include_global_state=include_global_state,
                                 partial=partial)

--- a/curator/api/utils.py
+++ b/curator/api/utils.py
@@ -248,10 +248,8 @@ def prune_closed(client, indices):
     :rtype: list
     """
     indices = ensure_list(indices)
-    logger.debug("BUH! indices = {0}".format(indices))
     retval = []
     for idx in list(indices):
-        logger.debug("HEY! idx = {0}".format(idx))
         if not index_closed(client, idx):
             retval.append(idx)
         else:

--- a/test/unit/test_api_commands.py
+++ b/test/unit/test_api_commands.py
@@ -346,6 +346,7 @@ class TestSnapshot(TestCase):
         self.assertFalse(curator.create_snapshot(client, indices=[], repository=repo_name, name=snap_name))
     def test_create_snapshot_verify_nodes_positive(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '1.4.4'} }
         client.cluster.state.return_value = open_indices
         client.snapshot.get.return_value = snapshots
         client.snapshot.verify_repository.return_value = verified_nodes
@@ -359,6 +360,7 @@ class TestSnapshot(TestCase):
         )
     def test_create_snapshot_verify_nodes_negative(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '1.4.4'} }
         client.cluster.state.return_value = open_indices
         client.snapshot.get.return_value = snapshots
         client.snapshot.verify_repository.return_value = verified_nodes
@@ -373,6 +375,7 @@ class TestSnapshot(TestCase):
         )
     def test_create_snapshot_name_collision(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '1.4.4'} }
         client.cluster.state.return_value = open_indices
         client.snapshot.get.return_value = snapshots
         client.snapshot.verify_repository.return_value = verified_nodes
@@ -388,6 +391,7 @@ class TestSnapshot(TestCase):
         )
     def test_create_snapshot_exception(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '1.4.4'} }
         client.cluster.state.return_value = open_indices
         client.snapshot.get.return_value = snapshots
         client.snapshot.verify_repository.return_value = verified_nodes


### PR DESCRIPTION
Apparently the method to verify that all nodes have access to the
repository is ES 1.4.0+ only:

`client.snapshot.verify_repository`

Updated a work-around and tested against 1.4.4 and 1.3.4